### PR TITLE
UTM-tag pyproject.toml Homepage + README marketing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > **The AI-native interface to your Revenue Operating System. Version-controlled GTM intelligence — signals, commits, and closed-loop measurement — accessible to any AI agent.**
 
-A Model Context Protocol (MCP) server that treats your Go-to-Market strategy like code: versioned, diffable, and deployable. Detect pipeline signals, identify scaling constraints, analyze value engines, and draft structured GTM changes — all through AI-native tool calls. Built on the [Artefact Formula](https://artefactventures.com) methodology from real B2B consulting engagements.
+A Model Context Protocol (MCP) server that treats your Go-to-Market strategy like code: versioned, diffable, and deployable. Detect pipeline signals, identify scaling constraints, analyze value engines, and draft structured GTM changes — all through AI-native tool calls. Built on the [Artefact Formula](https://artefactventures.com/en/mcp?utm_campaign=always_on-community-demand-github-readme-mcp-mcp_server-na-github&utm_medium=referral&utm_source=github.com&utm_content=documentation-readme-landing-link-en&utm_term=developer-na) methodology from real B2B consulting engagements.
 
 ## Why Artefact MCP?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/alexboissAV/artefact-mcp-server"
+Homepage = "https://artefactventures.com/en/mcp?utm_campaign=always_on-community-demand-mcp-pypi-listing-mcp_server-na-pypi&utm_medium=marketplace&utm_source=pypi.org&utm_content=documentation-package-page-link-en&utm_term=developer-na"
 Documentation = "https://github.com/alexboissAV/artefact-mcp-server#readme"
 Repository = "https://github.com/alexboissAV/artefact-mcp-server"
 Issues = "https://github.com/alexboissAV/artefact-mcp-server/issues"


### PR DESCRIPTION
## Summary

Retrofit the two highest-leverage marketing links per Artefact's new UTM convention 2026 ([artefact-ai-workspace#17](https://github.com/artefactventures/artefact-ai-workspace/pull/17)). Closes F2 (UTM hygiene at 2%) for the MCP-server channel slice.

- **pyproject.toml** `Homepage` → \`artefactventures.com/en/mcp\` with PyPI-specific UTMs. Affects the headline link in PyPI's package page sidebar on next release.
- **README.md** "Artefact Formula" anchor → UTM-tagged URL with GitHub-as-source UTMs. Affects GitHub readers + PyPI long_description + any MCP directory that scrapes README (Smithery, Claude directory, modelcontextprotocol/servers).

Documentation / Repository / Issues URLs in pyproject.toml stay GitHub-pointing — semantically those are "source URL" fields for devs, not marketing front doors.

## What propagates where

| Channel | Source | When live |
|---|---|---|
| PyPI sidebar | pyproject.toml Homepage | Next release |
| Smithery listing | pyproject.toml + smithery.yaml | Next release / auto-pull |
| Claude / Anthropic directory | README scrape | Next directory crawl |
| GitHub repo readers | README.md | Immediately on merge |

## Out of scope (separate cleanup PR)

\`alexboissAV\` → \`artefactventures\` GitHub owner mismatch present in:
- pyproject.toml Documentation / Repository / Issues
- server.json \`repository.url\` + \`name\`
- llms.txt several links
- README star-history badge

Tracked as a separate concern; not bundled here to keep this PR single-purpose.

## Test plan

- [x] \`git diff\` shows exactly 2 lines changed across 2 files.
- [ ] After merge: cut next release, verify PyPI sidebar shows the new URL.
- [ ] After release: click the PyPI link, confirm GA4 receives a session with \`utm_source=pypi.org, utm_medium=marketplace, utm_campaign=always_on-community-demand-mcp-pypi-listing-mcp_server-na-pypi\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)